### PR TITLE
Reverted the option for virtual service in global and not needed.

### DIFF
--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -61,7 +61,6 @@ mvn clean compile
 - `generateSupportingFiles` - generate the supporting files (`true` by default)
 - `supportingFilesToGenerate` - A comma separated list of supporting files to generate.  All files is the default.
 - `skip` - skip code generation (`false` by default. Can also be set globally through the `codegen.skip` property)
-- `virtualService` - virtualized service code generation (`false` by default. Only available if `generator-name` is `spring`)
 
 ### Custom Generator
 

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -138,14 +138,6 @@ public class CodeGenMojo extends AbstractMojo {
     @Parameter(name = "apiPackage")
     private String apiPackage;
 
-    
-    /**
-     * The package to use for generated virtualServices
-     */
-    @Parameter(name = "virtualService")
-    private Boolean virtualService;
-    
-    
     /**
      * The package to use for generated model objects/classes
      */
@@ -457,11 +449,6 @@ public class CodeGenMojo extends AbstractMojo {
             System.clearProperty(CodegenConstants.MODELS);
         }
 
-        if (null != virtualService && virtualService) {
-        	configurator.setVirtualService(String.valueOf(virtualService.booleanValue()));
-        } 
-
-        
         if (null != generateSupportingFiles && generateSupportingFiles) {
             System.setProperty(CodegenConstants.SUPPORTING_FILES, supportingFilesToGenerate);
         } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -80,7 +80,6 @@ public class CodegenConfigurator implements Serializable {
     private boolean verbose;
     private boolean skipOverwrite;
     private boolean removeOperationIdPrefix;
-    private String virtualService;
     private String templateDir;
     private String auth;
     private String apiPackage;
@@ -498,7 +497,7 @@ public class CodegenConfigurator implements Serializable {
         checkAndSetAdditionalProperty(gitRepoId, CodegenConstants.GIT_REPO_ID);
         checkAndSetAdditionalProperty(releaseNote, CodegenConstants.RELEASE_NOTE);
         checkAndSetAdditionalProperty(httpUserAgent, CodegenConstants.HTTP_USER_AGENT);
-        checkAndSetAdditionalProperty(virtualService,  CodegenConstants.VIRTUAL_SERVICE);
+
         handleDynamicProperties(config);
 
         if (isNotEmpty(library)) {
@@ -596,13 +595,5 @@ public class CodegenConfigurator implements Serializable {
         }
         return null;
     }
-    
-    public String getVirtualService() {
-        return virtualService;
-    }
-    
-    public void setVirtualService(String virtualService) {
-        this.virtualService = virtualService;
-    }
-    
+
 }


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

